### PR TITLE
Show different versions of a crate separately 

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,3 @@
-use std::io::Write;
 use std::ascii::AsciiExt;
 use std::fmt;
 

--- a/src/dep.rs
+++ b/src/dep.rs
@@ -10,37 +10,65 @@ pub enum DepKind {
     Unk,
 }
 
-#[derive(Debug, PartialEq)]
-pub struct Dep {
+#[derive(Debug)]
+pub struct DeclaredDep {
     pub name: String,
     pub kind: DepKind,
-    pub ver: Option<String>,
 }
 
-impl Dep {
+impl DeclaredDep {
     pub fn with_kind(name: String, kind: DepKind) -> Self {
-        Dep {
+        DeclaredDep {
             name: name,
             kind: kind,
-            ver: None,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct ResolvedDep {
+    pub name: String,
+    pub ver: String,
+    pub is_build: bool,
+    pub is_optional: bool,
+    pub is_dev: bool,
+    pub force_write_ver: bool,
+}
+
+impl ResolvedDep {
+    pub fn new(name: String, ver: String) -> Self {
+        ResolvedDep {
+            name: name,
+            ver: ver,
+            is_build: false,
+            is_optional: false,
+            is_dev: false,
+            force_write_ver: false,
         }
     }
 
-    pub fn ver<S: Into<String>>(&mut self, ver: S) {
-        self.ver = Some(ver.into());
+    pub fn kind(&self) -> DepKind {
+        if self.is_build {
+            DepKind::Build
+        } else if self.is_dev {
+            DepKind::Dev
+        } else if self.is_optional {
+            DepKind::Optional
+        } else {
+            DepKind::Unk
+        }
     }
 
     pub fn label<W: Write>(&self, w: &mut W, c: &Config) -> Result<()> {
-        let name = if c.include_vers {
-            format!("{}{}", self.name, if let Some(ref v) = self.ver { format!(" v{}", v) } else { String::new() })
+        let name = if self.force_write_ver || c.include_vers {
+            format!("{} v{}", self.name, self.ver)
         } else {
             self.name.clone()
         };
-        match self.kind {
+        match self.kind() {
             DepKind::Dev => writeln!(w, "[label={:?}{}];", name, c.dev_style),
             DepKind::Optional => writeln!(w, "[label={:?}{}];", name, c.optional_style),
             _ => writeln!(w, "[label={:?}{}];", name, c.build_style),
         }
-
     }
 }


### PR DESCRIPTION
Previously, `cargo graph` would merge all versions of a crate into a single node. However, a dependency graph may include multiple versions of the same crate. It is helpful to have a graph that shows which dependencies bring in an older version of a crate.

Now, instead of using only the name to identify a node in the graph, we use both the name and the version. For the project's direct dependencies, we take the version from the `[root]` table in Cargo.lock.

Since Cargo.toml doesn't contain the actual version used for dependencies, we can't properly initialize the list of dependencies while parsing Cargo.toml. However, Cargo.toml contains one piece of information that isn't in Cargo.lock: the kind of dependency (build, dev or optional). Instead of using a single `Dep` struct to store the information from both sources, we now use two structs: `DeclaredDep`, which represents a dependency declared in Cargo.toml, and `ResolvedDep`, which represents a resolved dependency in Cargo.lock.

The kind of dependency on a `ResolvedDep` is propagated to indirect dependencies once the whole graph has been filled. Instead of having a single kind on a `ResolvedDep`, we use a set of flags so that we assign the correct kind when an indirect dependency is used through direct dependencies with different kinds.

When `--include-versions` is not passed, nodes for crates with multiple versions in the graph will show the version anyway, in order to disambiguate the nodes that would otherwise have the same text.

Closes #27. Closes #28.